### PR TITLE
Piccoli aggiustamenti

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
         <a href="index_en.html">EN</a>
 </div>
 
-<h1 itemprop="name">Matrimonio Cate & Gigi</h1>
+<h1 itemprop="name">Matrimonio Cate&nbsp;&&nbsp;Gigi</h1>
         <p>Siete invitati al nostro matrimonio che si terrà sabato 12 settembre 2020 a Udine presso
             la chiesa di San Domenico, alle 11:00. </p>
 

--- a/index_en.html
+++ b/index_en.html
@@ -12,7 +12,7 @@
         <a href="index_en.html">EN</a>
 </div>
 
-<h1 itemprop="name">Gigi & Cate's wedding</h1>
+<h1 itemprop="name">Gigi&nbsp;&&nbsp;Cate's wedding</h1>
         <p>You are invited to our wedding! It will be celebrated Saturday, the 12th of September 2020
             in the Chiesa di San Domenico in Udine, at 11 am. </p>
 

--- a/location.html
+++ b/location.html
@@ -16,7 +16,7 @@
    <div class="mapouter"><div
            class="gmap_canvas"><iframe
            width="350" height="250"
-           id="gmap_canvas"
+           id="gmap_canvas_ceremony"
            src="https://maps.google.com/maps?q=chiesa%20san%20domenico%20udine%20-parrocchia&t=&z=13&ie=UTF8&iwloc=&output=embed"
            frameborder="0" scrolling="no" marginheight="0"
            marginwidth="0"></iframe>
@@ -25,7 +25,7 @@
    <div class="mapouter"><div
        class="gmap_canvas"><iframe
        width="350" height="250"
-       id="gmap_canvas"
+       id="gmap_canvas_party"
        src="https://maps.google.com/maps?q=azienda%20agricola%20petrucco%20di%20lina%20e%20paolo&t=&z=13&ie=UTF8&iwloc=&output=embed"
        frameborder="0" scrolling="no" marginheight="0"
        marginwidth="0"></iframe>

--- a/location_en.html
+++ b/location_en.html
@@ -17,7 +17,7 @@
    <div class="mapouter"><div
            class="gmap_canvas"><iframe
            width="350" height="250"
-           id="gmap_canvas"
+           id="gmap_canvas_ceremony"
            src="https://maps.google.com/maps?q=chiesa%20san%20domenico%20udine%20-parrocchia&t=&z=13&ie=UTF8&iwloc=&output=embed"
            frameborder="0" scrolling="no" marginheight="0"
            marginwidth="0"></iframe>
@@ -26,7 +26,7 @@
    <div class="mapouter"><div
        class="gmap_canvas"><iframe
        width="350" height="250"
-       id="gmap_canvas"
+       id="gmap_canvas_party"
        src="https://maps.google.com/maps?q=azienda%20agricola%20petrucco%20di%20lina%20e%20paolo&t=&z=13&ie=UTF8&iwloc=&output=embed"
        frameborder="0" scrolling="no" marginheight="0"
        marginwidth="0"></iframe>

--- a/style.css
+++ b/style.css
@@ -57,10 +57,12 @@ ul {
   margin-top: 0.5em;
 }
 
+.gmap_canvas iframe {
+  width: 100%;
+}
+
 @media all and (max-width: 600px) {
   body {
-  width: 80%;
+    width: 80%;
   }
-
-
 }


### PR DESCRIPTION
1. Aggiungendo i non-breaking space nel titolo "Cate & Gigi" rimangono sempre sulla stessa riga. In questo modo su mobile il titolo rimane ben bilanciato.
2. Lasciamo che le mappe tengano il 100% della larghezza. Tanto il `body` ha una larghezza fissa su desktop e dell'80% su mobile. In questo modo le mappe non hanno una larghezza fissa e su mobile non finiscono fuori dallo schermo (nel caso in cui l'80% dello schermo sia minore di 350px,che è la `width` degli `iframe`)
3. Una finezza sugli `iframe`: gli `id` all'interno di una pagina dovrebbero essere univoci.